### PR TITLE
Adding name to Change Requests

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,10 +10,12 @@ export {
 } from './permissions';
 export {
     BadRefNamingFormatError,
-    FamilyCounterLimitError,
+    NamingCounterLimitError,
     PartRefNaming,
     PartRefComps,
     PartRefFormatMismatchError,
+    ChangeRequestNaming,
+    ChangeRequestComps,
 } from './naming';
 export { arraysHaveSameMembers, arraysHaveSameMembersMut, CharIterator } from './util';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,9 +12,9 @@ export {
     BadRefNamingFormatError,
     FamilyCounterLimitError,
     PartRefNaming,
-    PartRefParts,
-    RefNameFormatMismatchError,
-} from './ref-naming';
+    PartRefComps,
+    PartRefFormatMismatchError,
+} from './naming';
 export { arraysHaveSameMembers, arraysHaveSameMembersMut, CharIterator } from './util';
 export {
     BadVersionFormatError,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -290,6 +290,7 @@ export interface ChangeReview extends Tracked {
 
 export interface ChangeRequest extends Tracked {
     id: Id;
+    name: string;
     description?: string;
     cycle: ChangeRequestCycle;
     state?: ApprovalDecision;

--- a/packages/core/src/naming/base.ts
+++ b/packages/core/src/naming/base.ts
@@ -1,0 +1,116 @@
+import { CharIterator } from '../util';
+import { BadRefNamingFormatError, Naming } from '.';
+
+export enum Kind {
+    Lit,
+    Var,
+}
+
+export interface LitToken {
+    kind: Kind.Lit;
+    value: string;
+}
+
+export interface VarToken {
+    kind: Kind.Var;
+    ident: string;
+    arg?: string;
+}
+
+export type Token = LitToken | VarToken;
+
+export function parseVar(inp: CharIterator, allowedVars: string[]): VarToken {
+    /* istanbul ignore next */
+    if (inp.read(2) != '${') {
+        throw new Error('variables start with "${');
+    }
+    const content = inp.readUntil('}', { throws: true, including: false });
+    inp.next(); // eat '}'
+
+    const [ident, arg] = content.split(':');
+    if (!allowedVars.includes(ident)) {
+        throw new BadRefNamingFormatError(`unknown variable "${ident}"`);
+    }
+    return {
+        kind: Kind.Var,
+        ident,
+        arg,
+    };
+}
+
+export function parseLiteral(inp: CharIterator): LitToken {
+    return {
+        kind: Kind.Lit,
+        value: inp.readUntil('${', { throws: false, including: false }),
+    };
+}
+
+export function parseNaming(
+    inp: CharIterator,
+    allowedVars: string[],
+    requiredVars: string[] = []
+): Token[] {
+    const toks = [];
+    while (!inp.done) {
+        if (inp.lookAhead(2) === '${') {
+            const vtok = parseVar(inp, allowedVars);
+            requiredVars = requiredVars.filter((v) => v !== vtok.ident);
+            toks.push(vtok);
+        } else {
+            toks.push(parseLiteral(inp));
+        }
+    }
+
+    if (requiredVars.length) {
+        const vars = requiredVars.join('\n - ');
+        throw new BadRefNamingFormatError(
+            `missing required variable(s) in naming format:\n - ${vars}`
+        );
+    }
+    return toks;
+}
+
+export interface TokenConfig<VarTok extends VarToken> {
+    mapTok(tok: VarToken): VarTok;
+}
+
+export abstract class NamingBase<Comps, VarTok extends VarToken> implements Naming<Comps> {
+    protected readonly tokens: (LitToken | VarTok)[];
+    constructor(
+        input: string,
+        tokenConf: TokenConfig<VarTok>,
+        allowedVars: string[],
+        requiredVars: string[] = []
+    ) {
+        const tokens = parseNaming(new CharIterator(input), allowedVars, requiredVars);
+        this.tokens = tokens.map((t) => {
+            switch (t.kind) {
+                case Kind.Lit:
+                    return t;
+                case Kind.Var:
+                    return tokenConf.mapTok(t);
+            }
+        });
+    }
+
+    protected abstract compSeg(tok: VarTok, comps: Comps): string;
+
+    buildName(comps: Comps): string {
+        const segs = [];
+        for (const tok of this.tokens) {
+            switch (tok.kind) {
+                case Kind.Lit: {
+                    segs.push(tok.value);
+                    break;
+                }
+                case Kind.Var: {
+                    segs.push(this.compSeg(tok, comps));
+                    break;
+                }
+            }
+        }
+        return segs.join('');
+    }
+
+    abstract extractComps(name: string): Comps;
+}

--- a/packages/core/src/naming/base.ts
+++ b/packages/core/src/naming/base.ts
@@ -111,6 +111,4 @@ export abstract class NamingBase<Comps, VarTok extends VarToken> implements Nami
         }
         return segs.join('');
     }
-
-    abstract extractComps(name: string): Comps;
 }

--- a/packages/core/src/naming/change-request.ts
+++ b/packages/core/src/naming/change-request.ts
@@ -1,0 +1,51 @@
+import { Kind, NamingBase, VarToken } from './base';
+import { NamingCounterLimitError } from '.';
+
+export interface ChangeRequestComps {
+    counter: number;
+}
+
+interface CounterToken {
+    kind: Kind.Var;
+    ident: 'counter';
+    width: number;
+}
+
+type ChangeRequestToken = CounterToken;
+
+export class ChangeRequestNaming extends NamingBase<ChangeRequestComps, ChangeRequestToken> {
+    constructor(input: string) {
+        super(
+            input,
+            {
+                mapTok(tok: VarToken): ChangeRequestToken {
+                    switch (tok.ident) {
+                        case 'counter':
+                            return {
+                                kind: Kind.Var,
+                                ident: 'counter',
+                                width: parseInt(tok.arg),
+                            };
+                    }
+                },
+            },
+            ['counter'],
+            ['counter']
+        );
+    }
+
+    protected compSeg(tok: ChangeRequestToken, comps: ChangeRequestComps): string {
+        switch (tok.ident) {
+            case 'counter': {
+                const cs = comps.counter.toString();
+                if (cs.length > tok.width) {
+                    throw new NamingCounterLimitError(
+                        `Change Request "${comps.counter}" has reached the maximum number of names. ` +
+                            'Consider upgrading your reference system.'
+                    );
+                }
+                return cs.padStart(tok.width, '0');
+            }
+        }
+    }
+}

--- a/packages/core/src/naming/index.ts
+++ b/packages/core/src/naming/index.ts
@@ -1,0 +1,72 @@
+import { CharIterator } from '../util';
+
+export {
+    PartRefComps,
+    PartRefFormatMismatchError,
+    PartRefNaming,
+    FamilyCounterLimitError,
+} from './part-ref';
+
+export class BadRefNamingFormatError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'BadRefNamingFormatError';
+        Error.captureStackTrace(this, BadRefNamingFormatError);
+    }
+}
+
+export enum Kind {
+    Lit,
+    Var,
+}
+
+export interface LitToken {
+    kind: Kind.Lit;
+    value: string;
+}
+
+export interface VarToken {
+    kind: Kind.Var;
+    ident: string;
+    arg: string;
+}
+
+export type Token = LitToken | VarToken;
+
+export function parseVar(inp: CharIterator, allowedVars: string[]): VarToken {
+    /* istanbul ignore next */
+    if (inp.read(2) != '${') {
+        throw new Error('variables start with "${');
+    }
+    const content = inp.readUntil('}', { throws: true, including: false });
+    inp.next(); // eat '}'
+
+    const [ident, arg] = content.split(':');
+    if (!allowedVars.includes(ident)) {
+        throw new BadRefNamingFormatError(`unknown variable "${ident}"`);
+    }
+    return {
+        kind: Kind.Var,
+        ident,
+        arg,
+    };
+}
+
+export function parseLiteral(inp: CharIterator): LitToken {
+    return {
+        kind: Kind.Lit,
+        value: inp.readUntil('${', { throws: false, including: false }),
+    };
+}
+
+export function parseNaming(inp: CharIterator, allowedVars: string[]): Token[] {
+    const toks = [];
+    while (!inp.done) {
+        if (inp.lookAhead(2) === '${') {
+            toks.push(parseVar(inp, allowedVars));
+        } else {
+            toks.push(parseLiteral(inp));
+        }
+    }
+    return toks;
+}

--- a/packages/core/src/naming/index.ts
+++ b/packages/core/src/naming/index.ts
@@ -1,9 +1,5 @@
-export {
-    PartRefComps,
-    PartRefFormatMismatchError,
-    PartRefNaming,
-    FamilyCounterLimitError,
-} from './part-ref';
+export { PartRefComps, PartRefFormatMismatchError, PartRefNaming } from './part-ref';
+export { ChangeRequestComps, ChangeRequestNaming } from './change-request';
 
 export class BadRefNamingFormatError extends Error {
     constructor(message: string) {
@@ -13,7 +9,14 @@ export class BadRefNamingFormatError extends Error {
     }
 }
 
+export class NamingCounterLimitError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'NamingCounterLimitError';
+        Error.captureStackTrace(this, NamingCounterLimitError);
+    }
+}
+
 export interface Naming<Comps> {
     buildName(comps: Comps): string;
-    extractComps(name: string): Comps;
 }

--- a/packages/core/src/naming/index.ts
+++ b/packages/core/src/naming/index.ts
@@ -70,3 +70,8 @@ export function parseNaming(inp: CharIterator, allowedVars: string[]): Token[] {
     }
     return toks;
 }
+
+export interface Naming<Comps> {
+    buildName(comps: Comps): string;
+    extractComps(name: string): Comps;
+}

--- a/packages/core/src/naming/index.ts
+++ b/packages/core/src/naming/index.ts
@@ -1,5 +1,3 @@
-import { CharIterator } from '../util';
-
 export {
     PartRefComps,
     PartRefFormatMismatchError,
@@ -13,62 +11,6 @@ export class BadRefNamingFormatError extends Error {
         this.name = 'BadRefNamingFormatError';
         Error.captureStackTrace(this, BadRefNamingFormatError);
     }
-}
-
-export enum Kind {
-    Lit,
-    Var,
-}
-
-export interface LitToken {
-    kind: Kind.Lit;
-    value: string;
-}
-
-export interface VarToken {
-    kind: Kind.Var;
-    ident: string;
-    arg: string;
-}
-
-export type Token = LitToken | VarToken;
-
-export function parseVar(inp: CharIterator, allowedVars: string[]): VarToken {
-    /* istanbul ignore next */
-    if (inp.read(2) != '${') {
-        throw new Error('variables start with "${');
-    }
-    const content = inp.readUntil('}', { throws: true, including: false });
-    inp.next(); // eat '}'
-
-    const [ident, arg] = content.split(':');
-    if (!allowedVars.includes(ident)) {
-        throw new BadRefNamingFormatError(`unknown variable "${ident}"`);
-    }
-    return {
-        kind: Kind.Var,
-        ident,
-        arg,
-    };
-}
-
-export function parseLiteral(inp: CharIterator): LitToken {
-    return {
-        kind: Kind.Lit,
-        value: inp.readUntil('${', { throws: false, including: false }),
-    };
-}
-
-export function parseNaming(inp: CharIterator, allowedVars: string[]): Token[] {
-    const toks = [];
-    while (!inp.done) {
-        if (inp.lookAhead(2) === '${') {
-            toks.push(parseVar(inp, allowedVars));
-        } else {
-            toks.push(parseLiteral(inp));
-        }
-    }
-    return toks;
 }
 
 export interface Naming<Comps> {

--- a/packages/core/src/naming/part-ref.ts
+++ b/packages/core/src/naming/part-ref.ts
@@ -1,6 +1,6 @@
 import { VersionFormat } from '../version-format';
 import { CharIterator } from '../util';
-import { parseNaming, Kind, BadRefNamingFormatError, LitToken } from '.';
+import { parseNaming, Kind, BadRefNamingFormatError, LitToken, Naming } from '.';
 
 export class FamilyCounterLimitError extends Error {
     constructor(message: string) {
@@ -43,7 +43,7 @@ interface PartVersionToken {
 
 type PartRefToken = LitToken | FamCodeToken | FamCountToken | PartVersionToken;
 
-export class PartRefNaming {
+export class PartRefNaming implements Naming<PartRefComps> {
     private tokens: readonly PartRefToken[];
     versionFormat: VersionFormat;
 
@@ -112,7 +112,7 @@ export class PartRefNaming {
         }
     }
 
-    buildRef({ familyCode, familyCount, partVersion }: PartRefComps): string {
+    buildName({ familyCode, familyCount, partVersion }: PartRefComps): string {
         const segs = [];
         for (const tok of this.tokens) {
             switch (tok.kind) {
@@ -151,7 +151,7 @@ export class PartRefNaming {
         return segs.join('');
     }
 
-    extractParts(ref: string): PartRefComps {
+    extractComps(ref: string): PartRefComps {
         // part family code is the only one whose length is unknown,
         // so we have to loop tokens forward and then backward until we hit fam_code
         let familyCount: number;

--- a/packages/core/src/naming/part-ref.ts
+++ b/packages/core/src/naming/part-ref.ts
@@ -1,14 +1,6 @@
 import { VersionFormat } from '../version-format';
 import { NamingBase, Kind, VarToken } from './base';
-import { BadRefNamingFormatError } from '.';
-
-export class FamilyCounterLimitError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'FamilyCounterLimitError';
-        Error.captureStackTrace(this, FamilyCounterLimitError);
-    }
-}
+import { BadRefNamingFormatError, NamingCounterLimitError } from '.';
 
 export class PartRefFormatMismatchError extends Error {
     constructor(message: string) {
@@ -106,7 +98,7 @@ export class PartRefNaming extends NamingBase<PartRefComps, PartRefToken> {
             case 'fam_count': {
                 const cs = comps.familyCount.toString();
                 if (cs.length > tok.width) {
-                    throw new FamilyCounterLimitError(
+                    throw new NamingCounterLimitError(
                         `Part family "${comps.familyCode}" has reached the maximum number of references. ` +
                             'Consider upgrading your reference system.'
                     );

--- a/packages/core/test/naming.ts
+++ b/packages/core/test/naming.ts
@@ -1,276 +1,325 @@
 import { expect } from 'chai';
 import {
     BadRefNamingFormatError,
-    FamilyCounterLimitError,
+    NamingCounterLimitError,
     PartRefNaming,
     PartRefFormatMismatchError,
+    ChangeRequestNaming,
 } from '../src/naming';
 import { BadVersionFormatError } from '../src/version-format';
 
-describe('#PartRefNaming', function () {
-    describe('#ctor', function () {
-        it('should throw if missing ${fam_code}', function () {
-            function bad(): PartRefNaming {
-                return new PartRefNaming('${fam_count:5}.${part_version:AA}');
-            }
-            expect(bad).to.throw(BadRefNamingFormatError, 'fam_code');
+describe('Naming', function () {
+    describe('#PartRefNaming', function () {
+        describe('#ctor', function () {
+            it('should throw if missing ${fam_code}', function () {
+                function bad(): PartRefNaming {
+                    return new PartRefNaming('${fam_count:5}.${part_version:AA}');
+                }
+                expect(bad).to.throw(BadRefNamingFormatError, 'fam_code');
+            });
+            it('should throw if missing ${fam_count}', function () {
+                function bad(): PartRefNaming {
+                    return new PartRefNaming('${fam_code}.${part_version:AA}');
+                }
+                expect(bad).to.throw(BadRefNamingFormatError, 'fam_count');
+            });
+            it('should throw if missing ${fam_count} width', function () {
+                function bad(): PartRefNaming {
+                    return new PartRefNaming('${fam_code}${fam_count}${part_version:AA}');
+                }
+                expect(bad).to.throw(BadRefNamingFormatError, /fam_count.+width/);
+            });
+            it('should throw if wrong ${fam_count} width', function () {
+                function bad(): PartRefNaming {
+                    return new PartRefNaming('${fam_code}${fam_count:gerard}${part_version:AA}');
+                }
+                expect(bad).to.throw(BadRefNamingFormatError, /fam_count.+width/);
+            });
+            it('should throw if negative ${fam_count} width', function () {
+                function bad(): PartRefNaming {
+                    return new PartRefNaming('${fam_code}${fam_count:-4}${part_version:AA}');
+                }
+                expect(bad).to.throw(BadRefNamingFormatError, /fam_count.+width/);
+            });
+            it('should throw if zero ${fam_count} width', function () {
+                function bad(): PartRefNaming {
+                    return new PartRefNaming('${fam_code}${fam_count:0}${part_version:AA}');
+                }
+                expect(bad).to.throw(BadRefNamingFormatError, /fam_count.+width/);
+            });
+            it('should throw if missing ${part_version}', function () {
+                function bad(): PartRefNaming {
+                    return new PartRefNaming('${fam_code}${fam_count:5}');
+                }
+                expect(bad).to.throw(BadRefNamingFormatError, 'part_version');
+            });
+            it('should throw if missing ${part_version} format', function () {
+                function bad(): PartRefNaming {
+                    return new PartRefNaming('${fam_code}${fam_count:5}${part_version}');
+                }
+                expect(bad).to.throw(BadRefNamingFormatError, /part_version.+format/);
+            });
+            it('should throw if ill-formed ${part_version} format', function () {
+                function bad(): PartRefNaming {
+                    return new PartRefNaming('${fam_code}${fam_count:5}${part_version:*?}');
+                }
+                expect(bad).to.throw(BadVersionFormatError, '*?');
+            });
+            it('should throw if unknown var', function () {
+                function bad(): PartRefNaming {
+                    return new PartRefNaming('${fam_cool}${fam_count:5}${part_version:*?}');
+                }
+                expect(bad).to.throw(BadRefNamingFormatError, 'fam_cool');
+            });
+            it('should throw if fam_code with arg', function () {
+                function bad(): PartRefNaming {
+                    return new PartRefNaming('${fam_code:AA}${fam_count:5}${part_version:*?}');
+                }
+                expect(bad).to.throw(BadRefNamingFormatError, /fam_code.+arg/);
+            });
         });
-        it('should throw if missing ${fam_count}', function () {
-            function bad(): PartRefNaming {
-                return new PartRefNaming('${fam_code}.${part_version:AA}');
-            }
-            expect(bad).to.throw(BadRefNamingFormatError, 'fam_count');
+
+        describe('#extractComps', function () {
+            it('should extract #1', function () {
+                const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
+                expect(rn.extractComps('P.02345.AB')).to.deep.include({
+                    familyCode: 'P',
+                    familyCount: 2345,
+                    partVersion: 'AB',
+                });
+                expect(rn.extractComps('ASM.02345.AB')).to.deep.include({
+                    familyCode: 'ASM',
+                    familyCount: 2345,
+                    partVersion: 'AB',
+                });
+            });
+            it('should extract #2', function () {
+                const rn = new PartRefNaming('${part_version:AA}.${fam_code}.${fam_count:5}');
+                expect(rn.extractComps('AB.P.02345')).to.deep.include({
+                    familyCode: 'P',
+                    familyCount: 2345,
+                    partVersion: 'AB',
+                });
+                expect(rn.extractComps('AB.ASM.02345')).to.deep.include({
+                    familyCode: 'ASM',
+                    familyCount: 2345,
+                    partVersion: 'AB',
+                });
+            });
+            it('should extract #3', function () {
+                const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
+                expect(rn.extractComps('02345.AB.P')).to.deep.include({
+                    familyCode: 'P',
+                    familyCount: 2345,
+                    partVersion: 'AB',
+                });
+                expect(rn.extractComps('02345.AB.ASM')).to.deep.include({
+                    familyCode: 'ASM',
+                    familyCount: 2345,
+                    partVersion: 'AB',
+                });
+            });
+
+            it('should throw if no fam_code', function () {
+                const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
+                function bad(): any {
+                    return rn.extractComps('.01234.AB');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if no fam_count #1', function () {
+                const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
+                function bad(): any {
+                    return rn.extractComps('P..AB');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if no fam_count #2', function () {
+                const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
+                function bad(): any {
+                    return rn.extractComps('.P.AB');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if fam_count format mismatch #1', function () {
+                const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
+                function bad(): any {
+                    return rn.extractComps('P.01V43.AB');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if fam_count format mismatch #2', function () {
+                const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
+                function bad(): any {
+                    return rn.extractComps('01V43.AB.P');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if no part_version #1', function () {
+                const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
+                function bad(): any {
+                    return rn.extractComps('P.01234.');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if no part_version #2', function () {
+                const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
+                function bad(): any {
+                    return rn.extractComps('01234..P');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if part_version format mismatch #1', function () {
+                const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
+                function bad(): any {
+                    return rn.extractComps('P.01234.02');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if part_version format mismatch #2', function () {
+                const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
+                function bad(): any {
+                    return rn.extractComps('01234.02.P');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if missing literal #1', function () {
+                const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
+                function bad(): any {
+                    return rn.extractComps('P.01234AB');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if missing literal #2', function () {
+                const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
+                function bad(): any {
+                    return rn.extractComps('01234AB.P');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if unexpected literal #1', function () {
+                const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
+                function bad(): any {
+                    return rn.extractComps('P.01234-.02');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if unexpected literal #2', function () {
+                const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
+                function bad(): any {
+                    return rn.extractComps('01234-.AB.P');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if wrong literal #1', function () {
+                const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
+                function bad(): any {
+                    return rn.extractComps('P.01234-AB');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
+
+            it('should throw if wrong literal #2', function () {
+                const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
+                function bad(): any {
+                    return rn.extractComps('01234-AB.P');
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError);
+            });
         });
-        it('should throw if missing ${fam_count} width', function () {
-            function bad(): PartRefNaming {
-                return new PartRefNaming('${fam_code}${fam_count}${part_version:AA}');
-            }
-            expect(bad).to.throw(BadRefNamingFormatError, /fam_count.+width/);
-        });
-        it('should throw if wrong ${fam_count} width', function () {
-            function bad(): PartRefNaming {
-                return new PartRefNaming('${fam_code}${fam_count:gerard}${part_version:AA}');
-            }
-            expect(bad).to.throw(BadRefNamingFormatError, /fam_count.+width/);
-        });
-        it('should throw if negative ${fam_count} width', function () {
-            function bad(): PartRefNaming {
-                return new PartRefNaming('${fam_code}${fam_count:-4}${part_version:AA}');
-            }
-            expect(bad).to.throw(BadRefNamingFormatError, /fam_count.+width/);
-        });
-        it('should throw if zero ${fam_count} width', function () {
-            function bad(): PartRefNaming {
-                return new PartRefNaming('${fam_code}${fam_count:0}${part_version:AA}');
-            }
-            expect(bad).to.throw(BadRefNamingFormatError, /fam_count.+width/);
-        });
-        it('should throw if missing ${part_version}', function () {
-            function bad(): PartRefNaming {
-                return new PartRefNaming('${fam_code}${fam_count:5}');
-            }
-            expect(bad).to.throw(BadRefNamingFormatError, 'part_version');
-        });
-        it('should throw if missing ${part_version} format', function () {
-            function bad(): PartRefNaming {
-                return new PartRefNaming('${fam_code}${fam_count:5}${part_version}');
-            }
-            expect(bad).to.throw(BadRefNamingFormatError, /part_version.+format/);
-        });
-        it('should throw if ill-formed ${part_version} format', function () {
-            function bad(): PartRefNaming {
-                return new PartRefNaming('${fam_code}${fam_count:5}${part_version:*?}');
-            }
-            expect(bad).to.throw(BadVersionFormatError, '*?');
-        });
-        it('should throw if unknown var', function () {
-            function bad(): PartRefNaming {
-                return new PartRefNaming('${fam_cool}${fam_count:5}${part_version:*?}');
-            }
-            expect(bad).to.throw(BadRefNamingFormatError, 'fam_cool');
-        });
-        it('should throw if fam_code with arg', function () {
-            function bad(): PartRefNaming {
-                return new PartRefNaming('${fam_code:AA}${fam_count:5}${part_version:*?}');
-            }
-            expect(bad).to.throw(BadRefNamingFormatError, /fam_code.+arg/);
+
+        describe('#buildName', function () {
+            it('should get a reference', function () {
+                const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
+                expect(
+                    rn.buildName({
+                        familyCode: 'P',
+                        familyCount: 2350,
+                        partVersion: 'BC',
+                    })
+                ).to.equal('P.02350.BC');
+            });
+            it('should throw if familyCount reached its limit', function () {
+                const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
+                function bad(): string {
+                    return rn.buildName({
+                        familyCode: 'P',
+                        familyCount: 100000,
+                        partVersion: 'BC',
+                    });
+                }
+                expect(bad).to.throw(NamingCounterLimitError, 'P');
+            });
+            it('should throw if partVersion mismatches', function () {
+                const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
+                function bad(): string {
+                    return rn.buildName({
+                        familyCode: 'P',
+                        familyCount: 2350,
+                        partVersion: '04',
+                    });
+                }
+                expect(bad).to.throw(PartRefFormatMismatchError, '04');
+            });
         });
     });
 
-    describe('#extractComps', function () {
-        it('should extract #1', function () {
-            const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            expect(rn.extractComps('P.02345.AB')).to.deep.include({
-                familyCode: 'P',
-                familyCount: 2345,
-                partVersion: 'AB',
+    describe('#ChangeRequestNaming', function () {
+        describe('#ctor', function () {
+            it('should parse input string', function () {
+                function good() {
+                    return new ChangeRequestNaming('CR-${counter:4}');
+                }
+                expect(good).not.to.throw;
             });
-            expect(rn.extractComps('ASM.02345.AB')).to.deep.include({
-                familyCode: 'ASM',
-                familyCount: 2345,
-                partVersion: 'AB',
+            it('should fail if missing ${counter}', function () {
+                function bad() {
+                    return new ChangeRequestNaming('CR-blabla');
+                }
+                expect(bad).to.throw;
             });
-        });
-        it('should extract #2', function () {
-            const rn = new PartRefNaming('${part_version:AA}.${fam_code}.${fam_count:5}');
-            expect(rn.extractComps('AB.P.02345')).to.deep.include({
-                familyCode: 'P',
-                familyCount: 2345,
-                partVersion: 'AB',
+            it('should fail if missing ${counter:width}', function () {
+                function bad() {
+                    return new ChangeRequestNaming('CR-${counter}');
+                }
+                expect(bad).to.throw;
             });
-            expect(rn.extractComps('AB.ASM.02345')).to.deep.include({
-                familyCode: 'ASM',
-                familyCount: 2345,
-                partVersion: 'AB',
-            });
-        });
-        it('should extract #3', function () {
-            const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
-            expect(rn.extractComps('02345.AB.P')).to.deep.include({
-                familyCode: 'P',
-                familyCount: 2345,
-                partVersion: 'AB',
-            });
-            expect(rn.extractComps('02345.AB.ASM')).to.deep.include({
-                familyCode: 'ASM',
-                familyCount: 2345,
-                partVersion: 'AB',
+            it('should fail if unexpected ${variable}', function () {
+                function bad() {
+                    return new ChangeRequestNaming('CR-${variable}');
+                }
+                expect(bad).to.throw;
             });
         });
-
-        it('should throw if no fam_code', function () {
-            const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            function bad(): any {
-                return rn.extractComps('.01234.AB');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if no fam_count #1', function () {
-            const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            function bad(): any {
-                return rn.extractComps('P..AB');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if no fam_count #2', function () {
-            const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
-            function bad(): any {
-                return rn.extractComps('.P.AB');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if fam_count format mismatch #1', function () {
-            const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            function bad(): any {
-                return rn.extractComps('P.01V43.AB');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if fam_count format mismatch #2', function () {
-            const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
-            function bad(): any {
-                return rn.extractComps('01V43.AB.P');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if no part_version #1', function () {
-            const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            function bad(): any {
-                return rn.extractComps('P.01234.');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if no part_version #2', function () {
-            const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
-            function bad(): any {
-                return rn.extractComps('01234..P');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if part_version format mismatch #1', function () {
-            const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            function bad(): any {
-                return rn.extractComps('P.01234.02');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if part_version format mismatch #2', function () {
-            const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
-            function bad(): any {
-                return rn.extractComps('01234.02.P');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if missing literal #1', function () {
-            const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            function bad(): any {
-                return rn.extractComps('P.01234AB');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if missing literal #2', function () {
-            const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
-            function bad(): any {
-                return rn.extractComps('01234AB.P');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if unexpected literal #1', function () {
-            const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            function bad(): any {
-                return rn.extractComps('P.01234-.02');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if unexpected literal #2', function () {
-            const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
-            function bad(): any {
-                return rn.extractComps('01234-.AB.P');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if wrong literal #1', function () {
-            const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            function bad(): any {
-                return rn.extractComps('P.01234-AB');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-
-        it('should throw if wrong literal #2', function () {
-            const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
-            function bad(): any {
-                return rn.extractComps('01234-AB.P');
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError);
-        });
-    });
-
-    describe('#buildName', function () {
-        it('should get a reference', function () {
-            const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            expect(
-                rn.buildName({
-                    familyCode: 'P',
-                    familyCount: 2350,
-                    partVersion: 'BC',
-                })
-            ).to.equal('P.02350.BC');
-        });
-        it('should throw if familyCount reached its limit', function () {
-            const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            function bad(): string {
-                return rn.buildName({
-                    familyCode: 'P',
-                    familyCount: 100000,
-                    partVersion: 'BC',
-                });
-            }
-            expect(bad).to.throw(FamilyCounterLimitError, 'P');
-        });
-        it('should throw if partVersion mismatches', function () {
-            const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            function bad(): string {
-                return rn.buildName({
-                    familyCode: 'P',
-                    familyCount: 2350,
-                    partVersion: '04',
-                });
-            }
-            expect(bad).to.throw(PartRefFormatMismatchError, '04');
+        describe('#buildName', function () {
+            it('should build a name', function () {
+                const naming = new ChangeRequestNaming('CR-${counter:4}');
+                expect(naming.buildName({ counter: 345 })).to.equal('CR-0345');
+            });
+            it('should build a name if counter is one below max', function () {
+                const naming = new ChangeRequestNaming('CR-${counter:4}');
+                expect(naming.buildName({ counter: 9999 })).to.equal('CR-9999');
+            });
+            it('should throw if counter has reached max', function () {
+                const naming = new ChangeRequestNaming('CR-${counter:4}');
+                function bad() {
+                    return naming.buildName({ counter: 10000 });
+                }
+                expect(bad).to.throw(NamingCounterLimitError);
+            });
         });
     });
 });

--- a/packages/core/test/naming.ts
+++ b/packages/core/test/naming.ts
@@ -77,15 +77,15 @@ describe('#PartRefNaming', function () {
         });
     });
 
-    describe('#extractParts', function () {
+    describe('#extractComps', function () {
         it('should extract #1', function () {
             const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
-            expect(rn.extractParts('P.02345.AB')).to.deep.include({
+            expect(rn.extractComps('P.02345.AB')).to.deep.include({
                 familyCode: 'P',
                 familyCount: 2345,
                 partVersion: 'AB',
             });
-            expect(rn.extractParts('ASM.02345.AB')).to.deep.include({
+            expect(rn.extractComps('ASM.02345.AB')).to.deep.include({
                 familyCode: 'ASM',
                 familyCount: 2345,
                 partVersion: 'AB',
@@ -93,12 +93,12 @@ describe('#PartRefNaming', function () {
         });
         it('should extract #2', function () {
             const rn = new PartRefNaming('${part_version:AA}.${fam_code}.${fam_count:5}');
-            expect(rn.extractParts('AB.P.02345')).to.deep.include({
+            expect(rn.extractComps('AB.P.02345')).to.deep.include({
                 familyCode: 'P',
                 familyCount: 2345,
                 partVersion: 'AB',
             });
-            expect(rn.extractParts('AB.ASM.02345')).to.deep.include({
+            expect(rn.extractComps('AB.ASM.02345')).to.deep.include({
                 familyCode: 'ASM',
                 familyCount: 2345,
                 partVersion: 'AB',
@@ -106,12 +106,12 @@ describe('#PartRefNaming', function () {
         });
         it('should extract #3', function () {
             const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
-            expect(rn.extractParts('02345.AB.P')).to.deep.include({
+            expect(rn.extractComps('02345.AB.P')).to.deep.include({
                 familyCode: 'P',
                 familyCount: 2345,
                 partVersion: 'AB',
             });
-            expect(rn.extractParts('02345.AB.ASM')).to.deep.include({
+            expect(rn.extractComps('02345.AB.ASM')).to.deep.include({
                 familyCode: 'ASM',
                 familyCount: 2345,
                 partVersion: 'AB',
@@ -121,7 +121,7 @@ describe('#PartRefNaming', function () {
         it('should throw if no fam_code', function () {
             const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
             function bad(): any {
-                return rn.extractParts('.01234.AB');
+                return rn.extractComps('.01234.AB');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -129,7 +129,7 @@ describe('#PartRefNaming', function () {
         it('should throw if no fam_count #1', function () {
             const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
             function bad(): any {
-                return rn.extractParts('P..AB');
+                return rn.extractComps('P..AB');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -137,7 +137,7 @@ describe('#PartRefNaming', function () {
         it('should throw if no fam_count #2', function () {
             const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
             function bad(): any {
-                return rn.extractParts('.P.AB');
+                return rn.extractComps('.P.AB');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -145,7 +145,7 @@ describe('#PartRefNaming', function () {
         it('should throw if fam_count format mismatch #1', function () {
             const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
             function bad(): any {
-                return rn.extractParts('P.01V43.AB');
+                return rn.extractComps('P.01V43.AB');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -153,7 +153,7 @@ describe('#PartRefNaming', function () {
         it('should throw if fam_count format mismatch #2', function () {
             const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
             function bad(): any {
-                return rn.extractParts('01V43.AB.P');
+                return rn.extractComps('01V43.AB.P');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -161,7 +161,7 @@ describe('#PartRefNaming', function () {
         it('should throw if no part_version #1', function () {
             const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
             function bad(): any {
-                return rn.extractParts('P.01234.');
+                return rn.extractComps('P.01234.');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -169,7 +169,7 @@ describe('#PartRefNaming', function () {
         it('should throw if no part_version #2', function () {
             const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
             function bad(): any {
-                return rn.extractParts('01234..P');
+                return rn.extractComps('01234..P');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -177,7 +177,7 @@ describe('#PartRefNaming', function () {
         it('should throw if part_version format mismatch #1', function () {
             const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
             function bad(): any {
-                return rn.extractParts('P.01234.02');
+                return rn.extractComps('P.01234.02');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -185,7 +185,7 @@ describe('#PartRefNaming', function () {
         it('should throw if part_version format mismatch #2', function () {
             const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
             function bad(): any {
-                return rn.extractParts('01234.02.P');
+                return rn.extractComps('01234.02.P');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -193,7 +193,7 @@ describe('#PartRefNaming', function () {
         it('should throw if missing literal #1', function () {
             const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
             function bad(): any {
-                return rn.extractParts('P.01234AB');
+                return rn.extractComps('P.01234AB');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -201,7 +201,7 @@ describe('#PartRefNaming', function () {
         it('should throw if missing literal #2', function () {
             const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
             function bad(): any {
-                return rn.extractParts('01234AB.P');
+                return rn.extractComps('01234AB.P');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -209,7 +209,7 @@ describe('#PartRefNaming', function () {
         it('should throw if unexpected literal #1', function () {
             const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
             function bad(): any {
-                return rn.extractParts('P.01234-.02');
+                return rn.extractComps('P.01234-.02');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -217,7 +217,7 @@ describe('#PartRefNaming', function () {
         it('should throw if unexpected literal #2', function () {
             const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
             function bad(): any {
-                return rn.extractParts('01234-.AB.P');
+                return rn.extractComps('01234-.AB.P');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -225,7 +225,7 @@ describe('#PartRefNaming', function () {
         it('should throw if wrong literal #1', function () {
             const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
             function bad(): any {
-                return rn.extractParts('P.01234-AB');
+                return rn.extractComps('P.01234-AB');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
@@ -233,17 +233,17 @@ describe('#PartRefNaming', function () {
         it('should throw if wrong literal #2', function () {
             const rn = new PartRefNaming('${fam_count:5}.${part_version:AA}.${fam_code}');
             function bad(): any {
-                return rn.extractParts('01234-AB.P');
+                return rn.extractComps('01234-AB.P');
             }
             expect(bad).to.throw(PartRefFormatMismatchError);
         });
     });
 
-    describe('#buildRef', function () {
+    describe('#buildName', function () {
         it('should get a reference', function () {
             const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
             expect(
-                rn.buildRef({
+                rn.buildName({
                     familyCode: 'P',
                     familyCount: 2350,
                     partVersion: 'BC',
@@ -253,7 +253,7 @@ describe('#PartRefNaming', function () {
         it('should throw if familyCount reached its limit', function () {
             const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
             function bad(): string {
-                return rn.buildRef({
+                return rn.buildName({
                     familyCode: 'P',
                     familyCount: 100000,
                     partVersion: 'BC',
@@ -264,7 +264,7 @@ describe('#PartRefNaming', function () {
         it('should throw if partVersion mismatches', function () {
             const rn = new PartRefNaming('${fam_code}.${fam_count:5}.${part_version:AA}');
             function bad(): string {
-                return rn.buildRef({
+                return rn.buildName({
                     familyCode: 'P',
                     familyCount: 2350,
                     partVersion: '04',

--- a/packages/core/test/naming.ts
+++ b/packages/core/test/naming.ts
@@ -3,8 +3,8 @@ import {
     BadRefNamingFormatError,
     FamilyCounterLimitError,
     PartRefNaming,
-    RefNameFormatMismatchError,
-} from '../src/ref-naming';
+    PartRefFormatMismatchError,
+} from '../src/naming';
 import { BadVersionFormatError } from '../src/version-format';
 
 describe('#PartRefNaming', function () {
@@ -123,7 +123,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('.01234.AB');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if no fam_count #1', function () {
@@ -131,7 +131,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('P..AB');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if no fam_count #2', function () {
@@ -139,7 +139,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('.P.AB');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if fam_count format mismatch #1', function () {
@@ -147,7 +147,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('P.01V43.AB');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if fam_count format mismatch #2', function () {
@@ -155,7 +155,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('01V43.AB.P');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if no part_version #1', function () {
@@ -163,7 +163,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('P.01234.');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if no part_version #2', function () {
@@ -171,7 +171,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('01234..P');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if part_version format mismatch #1', function () {
@@ -179,7 +179,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('P.01234.02');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if part_version format mismatch #2', function () {
@@ -187,7 +187,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('01234.02.P');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if missing literal #1', function () {
@@ -195,7 +195,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('P.01234AB');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if missing literal #2', function () {
@@ -203,7 +203,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('01234AB.P');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if unexpected literal #1', function () {
@@ -211,7 +211,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('P.01234-.02');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if unexpected literal #2', function () {
@@ -219,7 +219,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('01234-.AB.P');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if wrong literal #1', function () {
@@ -227,7 +227,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('P.01234-AB');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
 
         it('should throw if wrong literal #2', function () {
@@ -235,7 +235,7 @@ describe('#PartRefNaming', function () {
             function bad(): any {
                 return rn.extractParts('01234-AB.P');
             }
-            expect(bad).to.throw(RefNameFormatMismatchError);
+            expect(bad).to.throw(PartRefFormatMismatchError);
         });
     });
 
@@ -270,7 +270,7 @@ describe('#PartRefNaming', function () {
                     partVersion: '04',
                 });
             }
-            expect(bad).to.throw(RefNameFormatMismatchError, '04');
+            expect(bad).to.throw(PartRefFormatMismatchError, '04');
         });
     });
 });

--- a/packages/demo-server/src/index.ts
+++ b/packages/demo-server/src/index.ts
@@ -82,7 +82,9 @@ function buildServerApi(pool: DbPool): EsServerApi {
         control,
         dao,
         cors: true,
-        refNaming: new PartRefNaming('${fam_code}${fam_count:4}${part_version:AA}'),
+        naming: {
+            partRef: new PartRefNaming('${fam_code}${fam_count:4}${part_version:AA}'),
+        },
     });
     api.koa.use(logger());
 

--- a/packages/demo-server/src/index.ts
+++ b/packages/demo-server/src/index.ts
@@ -1,7 +1,7 @@
 import events from 'events';
 import Koa from 'koa';
 import logger from 'koa-logger';
-import { buildDefaultAppRolePolicies, PartRefNaming } from '@engspace/core';
+import { buildDefaultAppRolePolicies, PartRefNaming, ChangeRequestNaming } from '@engspace/core';
 import { buildControllerSet, EsServerApi } from '@engspace/server-api';
 import {
     buildDaoSet,
@@ -84,6 +84,7 @@ function buildServerApi(pool: DbPool): EsServerApi {
         cors: true,
         naming: {
             partRef: new PartRefNaming('${fam_code}${fam_count:4}${part_version:AA}'),
+            changeRequest: new ChangeRequestNaming('$CR-${counter:4}'),
         },
     });
     api.koa.use(logger());

--- a/packages/server-api/src/control/change.ts
+++ b/packages/server-api/src/control/change.ts
@@ -362,9 +362,10 @@ export class ChangeControl {
             partForks.map((pc) => pc.partId)
         );
         for (let i = 0; i < parts.length; ++i) {
-            const refParts = config.refNaming.extractParts(parts[i].ref);
-            const newRef = config.refNaming.buildRef({
-                ...refParts,
+            const prn = config.naming.partRef;
+            const comps = prn.extractComps(parts[i].ref);
+            const newRef = prn.buildName({
+                ...comps,
                 partVersion: partForks[i].version,
             });
             if (await this.dao.part.checkRef(db, newRef)) {

--- a/packages/server-api/src/control/change.ts
+++ b/packages/server-api/src/control/change.ts
@@ -28,6 +28,7 @@ export class ChangeControl {
     async requestCreate(ctx: ApiContext, input: ChangeRequestInput): Promise<ChangeRequest> {
         assertUserPerm(ctx, 'change.create');
         const {
+            config,
             db,
             auth: { userId },
         } = ctx;
@@ -37,7 +38,10 @@ export class ChangeControl {
         if (input.partRevisions?.length > 0) {
             await this.checkPartRevisions(ctx, input.partRevisions);
         }
+        const counter = await this.dao.globalCounter.bumpChangeRequest(db);
+        const name = config.naming.changeRequest.buildName({ counter });
         const req = await this.dao.changeRequest.create(db, {
+            name,
             description: input.description,
             userId,
         });

--- a/packages/server-api/src/control/part.ts
+++ b/packages/server-api/src/control/part.ts
@@ -31,7 +31,7 @@ export class PartControl {
 
         const ref = await ctx.db.transaction(async (db) => {
             const fam = await this.dao.partFamily.bumpCounterById(db, input.familyId);
-            return ctx.config.refNaming.buildRef({
+            return ctx.config.naming.partRef.buildName({
                 familyCode: fam.code,
                 familyCount: fam.counter,
                 partVersion: input.initialVersion,
@@ -60,9 +60,9 @@ export class PartControl {
         assertUserPerm(ctx, 'part.create');
         const { userId } = ctx.auth;
         const part = await this.dao.part.byId(ctx.db, partId);
-        const prn = ctx.config.refNaming;
-        const { familyCode, familyCount, partVersion } = prn.extractParts(part.ref);
-        const ref = prn.buildRef({
+        const prn = ctx.config.naming.partRef;
+        const { familyCode, familyCount, partVersion } = prn.extractComps(part.ref);
+        const ref = prn.buildName({
             familyCode,
             familyCount,
             partVersion: version ?? prn.versionFormat.getNext(partVersion),

--- a/packages/server-api/src/graphql/schema/change.ts
+++ b/packages/server-api/src/graphql/schema/change.ts
@@ -138,6 +138,7 @@ export const typeDefs = gql`
     """
     type ChangeRequest implements Tracked {
         id: ID!
+        name: String!
         description: String
         cycle: ChangeRequestCycle!
         state: ApprovalDecision

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -21,6 +21,10 @@ import { attachDb, authJwtSecret, setAuthToken } from './internal';
 
 export { ControllerSet, buildControllerSet };
 
+export interface EsNaming {
+    partRef: PartRefNaming;
+}
+
 export interface EsServerConfig {
     rolePolicies: AppRolePolicies;
     storePath: string;
@@ -28,7 +32,7 @@ export interface EsServerConfig {
     dao: DaoSet;
     control: ControllerSet;
     cors: boolean;
-    refNaming: PartRefNaming;
+    naming: EsNaming;
     // this is for playground only
     sessionKeys?: string[];
 }

--- a/packages/server-api/src/index.ts
+++ b/packages/server-api/src/index.ts
@@ -7,7 +7,7 @@ import Koa from 'koa';
 import bodyParser from 'koa-bodyparser';
 import { GraphQLSchema } from 'graphql';
 import { DaoSet, Db, DbPool } from '@engspace/server-db';
-import { AppRolePolicies, AuthToken, PartRefNaming } from '@engspace/core';
+import { AppRolePolicies, AuthToken, PartRefNaming, ChangeRequestNaming } from '@engspace/core';
 import { ApiContext, buildControllerSet, ControllerSet } from './control';
 import { verifyJwt } from './crypto';
 import { GqlContext, gqlContextFactory } from './graphql/context';
@@ -23,6 +23,7 @@ export { ControllerSet, buildControllerSet };
 
 export interface EsNaming {
     partRef: PartRefNaming;
+    changeRequest: ChangeRequestNaming;
 }
 
 export interface EsServerConfig {

--- a/packages/server-api/test/change-request-query.ts
+++ b/packages/server-api/test/change-request-query.ts
@@ -15,24 +15,24 @@ describe('GraphQL ChangeRequest - Queries', function () {
         return pool.transaction(async (db) => {
             users = await th.createUsersAB(db);
             fam = await th.createPartFamily(db);
-            oldReq = await th.createChangeRequest(db, users.a);
+            oldReq = await th.createChangeRequest(db, users.a, 'CR-001');
             parts = {
                 p1: await th.createPart(
                     db,
                     fam,
                     users.a,
                     { ref: 'P001.A', designation: 'PART 1' },
-                    { withRev1: true, changeRequest: oldReq, bumpFamCounter: true }
+                    { withRev1: { changeRequest: oldReq }, bumpFamCounter: true }
                 ),
                 p2: await th.createPart(
                     db,
                     fam,
                     users.a,
                     { ref: 'P002.A', designation: 'PART 2' },
-                    { withRev1: true, changeRequest: oldReq, bumpFamCounter: true }
+                    { withRev1: { changeRequest: oldReq }, bumpFamCounter: true }
                 ),
             };
-            req = await th.createChangeRequest(db, users.a, {
+            req = await th.createChangeRequest(db, users.a, 'CR-002', {
                 description: 'A change request',
                 partCreations: [
                     {

--- a/packages/server-api/test/change-request-query.ts
+++ b/packages/server-api/test/change-request-query.ts
@@ -8,31 +8,31 @@ import { buildGqlServer, pool, th } from '.';
 describe('GraphQL ChangeRequest - Queries', function () {
     let users;
     let fam;
-    let oldReq;
+    let cr1;
     let parts;
-    let req;
+    let cr2;
     before(async function () {
         return pool.transaction(async (db) => {
             users = await th.createUsersAB(db);
             fam = await th.createPartFamily(db);
-            oldReq = await th.createChangeRequest(db, users.a, 'CR-001');
+            cr1 = await th.createChangeRequest(db, users.a, 'CR-001');
             parts = {
                 p1: await th.createPart(
                     db,
                     fam,
                     users.a,
                     { ref: 'P001.A', designation: 'PART 1' },
-                    { withRev1: { changeRequest: oldReq }, bumpFamCounter: true }
+                    { withRev1: { changeRequest: cr1 }, bumpFamCounter: true }
                 ),
                 p2: await th.createPart(
                     db,
                     fam,
                     users.a,
                     { ref: 'P002.A', designation: 'PART 2' },
-                    { withRev1: { changeRequest: oldReq }, bumpFamCounter: true }
+                    { withRev1: { changeRequest: cr1 }, bumpFamCounter: true }
                 ),
             };
-            req = await th.createChangeRequest(db, users.a, 'CR-002', {
+            cr2 = await th.createChangeRequest(db, users.a, 'CR-002', {
                 description: 'A change request',
                 partCreations: [
                     {
@@ -93,13 +93,13 @@ describe('GraphQL ChangeRequest - Queries', function () {
                 return query({
                     query: CHANGEREQ_READ,
                     variables: {
-                        id: req.id,
+                        id: cr2.id,
                     },
                 });
             });
             expect(errors).to.be.undefined;
             expect(data.changeRequest).to.containSubset({
-                id: req.id,
+                id: cr2.id,
                 description: 'A change request',
                 cycle: ChangeRequestCycle.Edition,
                 state: null,
@@ -156,7 +156,7 @@ describe('GraphQL ChangeRequest - Queries', function () {
                 return query({
                     query: CHANGEREQ_READ,
                     variables: {
-                        id: req.id,
+                        id: cr2.id,
                     },
                 });
             });

--- a/packages/server-api/test/helpers.ts
+++ b/packages/server-api/test/helpers.ts
@@ -43,6 +43,7 @@ export const PARTREV_FIELDS = gql`
 export const CHANGEREQ_DEEPFIELDS = gql`
     fragment ChangeReqDeepFields on ChangeRequest {
         id
+        name
         description
         cycle
         state

--- a/packages/server-api/test/index.ts
+++ b/packages/server-api/test/index.ts
@@ -27,6 +27,7 @@ import {
     AuthToken,
     buildDefaultAppRolePolicies,
     PartRefNaming,
+    ChangeRequestNaming,
 } from '@engspace/core';
 import { EsServerApi } from '../src';
 import { buildControllerSet } from '../src/control';
@@ -89,6 +90,7 @@ export const api = new EsServerApi(new Koa(), {
     cors: true,
     naming: {
         partRef: new PartRefNaming('${fam_code}${fam_count:3}.${part_version:A}'),
+        changeRequest: new ChangeRequestNaming('CR-${counter:3}'),
     },
 });
 

--- a/packages/server-api/test/index.ts
+++ b/packages/server-api/test/index.ts
@@ -87,7 +87,9 @@ export const api = new EsServerApi(new Koa(), {
     control,
     dao,
     cors: true,
-    refNaming: new PartRefNaming('${fam_code}${fam_count:3}.${part_version:A}'),
+    naming: {
+        partRef: new PartRefNaming('${fam_code}${fam_count:3}.${part_version:A}'),
+    },
 });
 
 api.setupAuthAndHttpRoutes('/api');

--- a/packages/server-api/test/part-mutation.ts
+++ b/packages/server-api/test/part-mutation.ts
@@ -6,25 +6,25 @@ import { permsAuth } from './auth';
 import { TRACKED_FIELDS } from './helpers';
 import { buildGqlServer, dao, pool, th } from '.';
 
-const PARTREV_DEEPFIELDS = gql`
-    fragment PartRevDeepFields on PartRevision {
-        id
-        revision
-        cycle
-        designation
-        ...TrackedFields
-        part {
-            id
-            designation
-            ref
-            ...TrackedFields
-            family {
-                id
-            }
-        }
-    }
-    ${TRACKED_FIELDS}
-`;
+// const PARTREV_DEEPFIELDS = gql`
+//     fragment PartRevDeepFields on PartRevision {
+//         id
+//         revision
+//         cycle
+//         designation
+//         ...TrackedFields
+//         part {
+//             id
+//             designation
+//             ref
+//             ...TrackedFields
+//             family {
+//                 id
+//             }
+//         }
+//     }
+//     ${TRACKED_FIELDS}
+// `;
 
 const PARTVAL_DEEPFIELDS = gql`
     fragment PartValDeepFields on PartValidation {

--- a/packages/server-api/test/part-mutation.ts
+++ b/packages/server-api/test/part-mutation.ts
@@ -55,7 +55,7 @@ const PARTVAL_DEEPFIELDS = gql`
 describe('GraphQL Part - Mutations', function () {
     let users: Dict<User>;
     let family;
-    let req;
+    let cr;
     before('create res', async function () {
         return pool.transaction(async (db) => {
             users = await th.createUsers(db, {
@@ -66,7 +66,7 @@ describe('GraphQL Part - Mutations', function () {
                 e: { name: 'e' },
             });
             family = await th.createPartFamily(db, { code: 'P' });
-            req = await th.createChangeRequest(db, users.a);
+            cr = await th.createChangeRequest(db, users.a);
         });
     });
     after('delete res', th.cleanTables(['part_family', 'change_request', 'user']));
@@ -533,7 +533,7 @@ describe('GraphQL Part - Mutations', function () {
                 part = await th.createPart(db, family, users.a, {
                     designation: 'SOME EXISTING PART',
                 });
-                partRev = await th.createPartRev(db, part, req, users.a);
+                partRev = await th.createPartRev(db, part, cr, users.a);
                 await dao.partFamily.bumpCounterById(db, family.id);
             });
         });
@@ -669,7 +669,7 @@ describe('GraphQL Part - Mutations', function () {
                 part = await th.createPart(db, family, users.a, {
                     designation: 'SOME EXISTING PART',
                 });
-                partRev = await th.createPartRev(db, part, req, users.a);
+                partRev = await th.createPartRev(db, part, cr, users.a);
                 partVal = await th.createPartVal(db, partRev, users.a);
                 partApprs = await th.createPartApprovals(db, partVal, users, users.a);
                 await dao.partFamily.bumpCounterById(db, family.id);
@@ -861,7 +861,7 @@ describe('GraphQL Part - Mutations', function () {
                 part = await th.createPart(db, family, users.a, {
                     designation: 'SOME EXISTING PART',
                 });
-                partRev = await th.createPartRev(db, part, req, users.a);
+                partRev = await th.createPartRev(db, part, cr, users.a);
                 partVal = await th.createPartVal(db, partRev, users.a);
                 partApprs = await th.createPartApprovals(db, partVal, users, users.a);
                 await dao.partFamily.bumpCounterById(db, family.id);

--- a/packages/server-api/test/part-query.ts
+++ b/packages/server-api/test/part-query.ts
@@ -78,7 +78,7 @@ const PARTAPPR_READ = gql`
 describe('GraphQL Part - Queries', function () {
     let users;
     let family;
-    let req;
+    let cr;
     let part;
     let partRev;
     let bef, aft;
@@ -93,9 +93,9 @@ describe('GraphQL Part - Queries', function () {
                 e: { name: 'e' },
             });
             family = await th.createPartFamily(db, { code: 'P' });
-            req = await th.createChangeRequest(db, users.a);
+            cr = await th.createChangeRequest(db, users.a);
             part = await th.createPart(db, family, users.a, {});
-            partRev = await th.createPartRev(db, part, req, users.a);
+            partRev = await th.createPartRev(db, part, cr, users.a);
         });
         aft = Date.now();
     });

--- a/packages/server-db/sql/3-schema.sql
+++ b/packages/server-db/sql/3-schema.sql
@@ -3,6 +3,10 @@ CREATE TABLE metadata (
     application_id text
 );
 
+CREATE TABLE global_counter (
+    change_request integer NOT NULL
+);
+
 CREATE TABLE "user" (
     id serial PRIMARY KEY,
     name text NOT NULL UNIQUE,

--- a/packages/server-db/sql/3-schema.sql
+++ b/packages/server-db/sql/3-schema.sql
@@ -64,6 +64,7 @@ CREATE TABLE part_family (
 
 CREATE TABLE change_request (
     id serial PRIMARY KEY,
+    name text NOT NULL,
     description text,
     cycle text NOT NULL,
 
@@ -71,6 +72,9 @@ CREATE TABLE change_request (
     created_at timestamptz NOT NULL,
     updated_by integer NOT NULL,
     updated_at timestamptz NOT NULL,
+
+    UNIQUE(name),
+    CHECK(LENGTH(name) > 0),
 
     FOREIGN KEY(cycle) REFERENCES change_request_cycle_enum(id),
     FOREIGN KEY(created_by) REFERENCES "user"(id),

--- a/packages/server-db/src/dao/global-counter.ts
+++ b/packages/server-db/src/dao/global-counter.ts
@@ -1,0 +1,15 @@
+import { sql } from 'slonik';
+import { Db } from '..';
+
+export class GlobalCounterDao {
+    peekChangeRequest(db: Db): Promise<number> {
+        return db.oneFirst(sql`SELECT change_request FROM global_counter`) as Promise<number>;
+    }
+
+    bumpChangeRequest(db: Db): Promise<number> {
+        return db.oneFirst(sql`
+            UPDATE global_counter SET change_request = change_request+1
+            RETURNING change_request
+        `) as Promise<number>;
+    }
+}

--- a/packages/server-db/src/dao/index.ts
+++ b/packages/server-db/src/dao/index.ts
@@ -16,6 +16,7 @@ import { PartValidationDao } from './part-validation';
 import { ProjectDao } from './project';
 import { ProjectMemberDao } from './project-member';
 import { UserDao } from './user';
+import { GlobalCounterDao } from './global-counter';
 
 export { ChangePartForkDaoInput } from './change-part-fork';
 export { ChangePartCreateDaoInput } from './change-part-create';
@@ -37,6 +38,7 @@ export {
     PartValidationDao,
     ProjectDao,
     UserDao,
+    GlobalCounterDao,
 };
 
 /**
@@ -55,6 +57,7 @@ export interface Dao<T extends HasId> {
 }
 
 export interface DaoSet {
+    globalCounter: GlobalCounterDao;
     user: UserDao;
     login: LoginDao;
     project: ProjectDao;
@@ -75,6 +78,7 @@ export interface DaoSet {
 
 export function buildDaoSet(custom: Partial<DaoSet> = {}): DaoSet {
     return {
+        globalCounter: custom.globalCounter ?? new GlobalCounterDao(),
         user: custom.user ?? new UserDao(),
         login: custom.login ?? new LoginDao(),
         project: custom.project ?? new ProjectDao(),

--- a/packages/server-db/src/schema.ts
+++ b/packages/server-db/src/schema.ts
@@ -47,6 +47,7 @@ async function createSchema(db: Db): Promise<void> {
     await executeSqlFile(db, sqlPath('2-enums.sql'));
     await executeSqlFile(db, sqlPath('3-schema.sql'));
     await executeSqlFolder(db, sqlPath('4-functions'));
+    await executeSqlFile(db, sqlPath('5-populate.sql'));
 }
 
 interface EnumTable {

--- a/packages/server-db/src/test-helpers.ts
+++ b/packages/server-db/src/test-helpers.ts
@@ -500,6 +500,14 @@ export class TestHelpers {
         });
     }
 
+    resetChangeCounter() {
+        return (): Promise<void> => {
+            return this.pool.transaction(async (db) => {
+                await db.query(sql`UPDATE global_counter SET change_request=0`);
+            });
+        };
+    }
+
     // Documents
 
     async createDoc(db: Db, user: User, input: Partial<DocumentInput> = {}): Promise<Document> {

--- a/packages/server-db/test/change-part-create.ts
+++ b/packages/server-db/test/change-part-create.ts
@@ -75,7 +75,7 @@ describe('#ChangePartCreateDao', function () {
         let partCreations;
         before(async function () {
             return pool.transaction(async (db) => {
-                req2 = await th.createChangeRequest(db, users.a);
+                req2 = await th.createChangeRequest(db, users.a, 'CR-002');
                 partCreations = [
                     await th.createChangePartCreate(db, req, fam, {
                         designation: 'PART A',

--- a/packages/server-db/test/change-part-create.ts
+++ b/packages/server-db/test/change-part-create.ts
@@ -3,12 +3,12 @@ import { dao, pool, th } from '.';
 
 describe('#ChangePartCreateDao', function () {
     let users;
-    let req;
+    let cr1;
     let fam;
     before(async function () {
         await pool.transaction(async (db) => {
             users = await th.createUsersAB(db);
-            req = await th.createChangeRequest(db, users.a);
+            cr1 = await th.createChangeRequest(db, users.a);
             fam = await th.createPartFamily(db);
         });
     });
@@ -20,14 +20,14 @@ describe('#ChangePartCreateDao', function () {
         it('should create a ChangePartCreate', async function () {
             const cpc = await pool.transaction(async (db) => {
                 return dao.changePartCreate.create(db, {
-                    requestId: req.id,
+                    requestId: cr1.id,
                     familyId: fam.id,
                     version: 'A',
                     designation: 'NEW PART',
                 });
             });
             expect(cpc).to.deep.include({
-                request: { id: req.id },
+                request: { id: cr1.id },
                 family: { id: fam.id },
                 version: 'A',
                 designation: 'NEW PART',
@@ -40,11 +40,11 @@ describe('#ChangePartCreateDao', function () {
         before(async function () {
             return pool.transaction(async (db) => {
                 partCreations = [
-                    await th.createChangePartCreate(db, req, fam, {
+                    await th.createChangePartCreate(db, cr1, fam, {
                         designation: 'PART A',
                         version: 'A',
                     }),
-                    await th.createChangePartCreate(db, req, fam, {
+                    await th.createChangePartCreate(db, cr1, fam, {
                         designation: 'PART B',
                         version: 'B',
                         comments: 'Some comment about part B',
@@ -57,7 +57,7 @@ describe('#ChangePartCreateDao', function () {
 
         it('should read ChangePartCreate by request id', async function () {
             const cpc = await pool.connect(async (db) => {
-                return dao.changePartCreate.byRequestId(db, req.id);
+                return dao.changePartCreate.byRequestId(db, cr1.id);
             });
             expect(cpc).to.have.same.deep.members(partCreations);
         });
@@ -71,17 +71,17 @@ describe('#ChangePartCreateDao', function () {
     });
 
     describe('#checkRequestId', function () {
-        let req2;
+        let cr2;
         let partCreations;
         before(async function () {
             return pool.transaction(async (db) => {
-                req2 = await th.createChangeRequest(db, users.a, 'CR-002');
+                cr2 = await th.createChangeRequest(db, users.a, 'CR-002');
                 partCreations = [
-                    await th.createChangePartCreate(db, req, fam, {
+                    await th.createChangePartCreate(db, cr1, fam, {
                         designation: 'PART A',
                         version: 'A',
                     }),
-                    await th.createChangePartCreate(db, req2, fam, {
+                    await th.createChangePartCreate(db, cr2, fam, {
                         designation: 'PART B',
                         version: 'B',
                     }),
@@ -92,7 +92,7 @@ describe('#ChangePartCreateDao', function () {
         after(th.cleanTable('change_part_create'));
         after(async function () {
             return pool.transaction(async (db) => {
-                return dao.changeRequest.deleteById(db, req2.id);
+                return dao.changeRequest.deleteById(db, cr2.id);
             });
         });
 
@@ -101,8 +101,8 @@ describe('#ChangePartCreateDao', function () {
                 paReqId: await dao.changePartCreate.checkRequestId(db, partCreations[0].id),
                 pbReqId: await dao.changePartCreate.checkRequestId(db, partCreations[1].id),
             }));
-            expect(paReqId).to.eql(req.id);
-            expect(pbReqId).to.eql(req2.id);
+            expect(paReqId).to.eql(cr1.id);
+            expect(pbReqId).to.eql(cr2.id);
         });
     });
 });

--- a/packages/server-db/test/change-part-fork.ts
+++ b/packages/server-db/test/change-part-fork.ts
@@ -3,13 +3,13 @@ import { dao, pool, th } from '.';
 
 describe('#ChangePartForkDao', function () {
     let users;
-    let req;
+    let cr;
     let fam;
     let part;
     before(async function () {
         await pool.transaction(async (db) => {
             users = await th.createUsersAB(db);
-            req = await th.createChangeRequest(db, users.a);
+            cr = await th.createChangeRequest(db, users.a);
             fam = await th.createPartFamily(db);
             part = await th.createPart(db, fam, users.a, {});
         });
@@ -22,13 +22,13 @@ describe('#ChangePartForkDao', function () {
         it('should create a ChangePartFork', async function () {
             const cpc = await pool.transaction(async (db) => {
                 return dao.changePartFork.create(db, {
-                    requestId: req.id,
+                    requestId: cr.id,
                     partId: part.id,
                     version: 'A',
                 });
             });
             expect(cpc).to.deep.include({
-                request: { id: req.id },
+                request: { id: cr.id },
                 part: { id: part.id },
                 version: 'A',
                 designation: null,
@@ -38,14 +38,14 @@ describe('#ChangePartForkDao', function () {
         it('should create a ChangePartFork with new designation', async function () {
             const cpc = await pool.transaction(async (db) => {
                 return dao.changePartFork.create(db, {
-                    requestId: req.id,
+                    requestId: cr.id,
                     partId: part.id,
                     version: 'A',
                     designation: 'NEW EXISTING PART',
                 });
             });
             expect(cpc).to.deep.include({
-                request: { id: req.id },
+                request: { id: cr.id },
                 part: { id: part.id },
                 version: 'A',
                 designation: 'NEW EXISTING PART',
@@ -58,11 +58,11 @@ describe('#ChangePartForkDao', function () {
         before(async function () {
             return pool.transaction(async (db) => {
                 partForks = [
-                    await th.createChangePartFork(db, req, part, {
+                    await th.createChangePartFork(db, cr, part, {
                         designation: 'PART A',
                         version: 'A',
                     }),
-                    await th.createChangePartFork(db, req, part, {
+                    await th.createChangePartFork(db, cr, part, {
                         designation: 'PART B',
                         version: 'B',
                         comments: 'Some comment about part B',
@@ -75,7 +75,7 @@ describe('#ChangePartForkDao', function () {
 
         it('should read ChangePartFork by request id', async function () {
             const cpc = await pool.connect(async (db) => {
-                return dao.changePartFork.byRequestId(db, req.id);
+                return dao.changePartFork.byRequestId(db, cr.id);
             });
             expect(cpc).to.have.same.deep.members(partForks);
         });

--- a/packages/server-db/test/change-part-revision.ts
+++ b/packages/server-db/test/change-part-revision.ts
@@ -3,13 +3,13 @@ import { dao, pool, th } from '.';
 
 describe('#ChangePartRevisionDao', function () {
     let users;
-    let req;
+    let cr;
     let fam;
     let part;
     before(async function () {
         await pool.transaction(async (db) => {
             users = await th.createUsersAB(db);
-            req = await th.createChangeRequest(db, users.a);
+            cr = await th.createChangeRequest(db, users.a);
             fam = await th.createPartFamily(db);
             part = await th.createPart(db, fam, users.a, {});
         });
@@ -22,12 +22,12 @@ describe('#ChangePartRevisionDao', function () {
         it('should create a ChangePartRevision', async function () {
             const cpr = await pool.transaction(async (db) => {
                 return dao.changePartRevision.create(db, {
-                    requestId: req.id,
+                    requestId: cr.id,
                     partId: part.id,
                 });
             });
             expect(cpr).to.deep.include({
-                request: { id: req.id },
+                request: { id: cr.id },
                 part: { id: part.id },
                 designation: null,
             });
@@ -36,13 +36,13 @@ describe('#ChangePartRevisionDao', function () {
         it('should create a ChangePartRevision with designation', async function () {
             const cpr = await pool.transaction(async (db) => {
                 return dao.changePartRevision.create(db, {
-                    requestId: req.id,
+                    requestId: cr.id,
                     partId: part.id,
                     designation: 'NEW EXISTING PART',
                 });
             });
             expect(cpr).to.deep.include({
-                request: { id: req.id },
+                request: { id: cr.id },
                 part: { id: part.id },
                 designation: 'NEW EXISTING PART',
             });
@@ -54,7 +54,7 @@ describe('#ChangePartRevisionDao', function () {
         before(async function () {
             return pool.transaction(async (db) => {
                 partRevisions = [
-                    await th.createChangePartRevision(db, req, part, {
+                    await th.createChangePartRevision(db, cr, part, {
                         designation: 'PART A',
                     }),
                 ];
@@ -65,7 +65,7 @@ describe('#ChangePartRevisionDao', function () {
 
         it('should read ChangePartRevision by request id', async function () {
             const cpr = await pool.connect(async (db) => {
-                return dao.changePartRevision.byRequestId(db, req.id);
+                return dao.changePartRevision.byRequestId(db, cr.id);
             });
             expect(cpr).to.have.same.deep.members(partRevisions);
         });

--- a/packages/server-db/test/change-request.ts
+++ b/packages/server-db/test/change-request.ts
@@ -24,10 +24,12 @@ describe('#ChangeRequestDao', function () {
         it('should create a ChangeRequest', async function () {
             const cr = await pool.transaction(async (db) => {
                 return dao.changeRequest.create(db, {
+                    name: 'CR-001',
                     userId: users.a.id,
                 });
             });
             expect(cr).to.deep.include({
+                name: 'CR-001',
                 description: null,
                 cycle: ChangeRequestCycle.Edition,
                 state: null,
@@ -39,15 +41,17 @@ describe('#ChangeRequestDao', function () {
         it('should create a ChangeRequest with description', async function () {
             const cr = await pool.transaction(async (db) => {
                 return dao.changeRequest.create(db, {
+                    name: 'CR-001',
                     userId: users.a.id,
                     description: 'SUPER CHANGE',
                 });
             });
             expect(cr).to.deep.include({
-                ...trackedBy(users.a),
+                name: 'CR-001',
                 description: 'SUPER CHANGE',
                 cycle: ChangeRequestCycle.Edition,
                 state: null,
+                ...trackedBy(users.a),
             });
             expect(cr.id).to.be.a(idType);
         });
@@ -55,15 +59,17 @@ describe('#ChangeRequestDao', function () {
         it('should create a ChangeRequest with initial cycle', async function () {
             const cr = await pool.transaction(async (db) => {
                 return dao.changeRequest.create(db, {
+                    name: 'CR-001',
                     userId: users.a.id,
                     cycle: ChangeRequestCycle.Validation,
                 });
             });
             expect(cr).to.deep.include({
-                ...trackedBy(users.a),
+                name: 'CR-001',
                 description: null,
                 cycle: ChangeRequestCycle.Validation,
                 state: ApprovalDecision.Approved,
+                ...trackedBy(users.a),
             });
             expect(cr.id).to.be.a(idType);
         });
@@ -74,6 +80,7 @@ describe('#ChangeRequestDao', function () {
         this.beforeEach(async function () {
             cr = await pool.transaction(async (db) => {
                 return dao.changeRequest.create(db, {
+                    name: 'CR-001',
                     description: 'SUPER CHANGE',
                     userId: users.a.id,
                     cycle: ChangeRequestCycle.Validation,
@@ -176,6 +183,7 @@ describe('#ChangeRequestDao', function () {
         this.beforeEach(async function () {
             cr = await pool.transaction(async (db) => {
                 return dao.changeRequest.create(db, {
+                    name: 'CR-001',
                     description: 'SUPER CHANGE',
                     userId: users.a.id,
                     cycle: ChangeRequestCycle.Validation,
@@ -193,6 +201,7 @@ describe('#ChangeRequestDao', function () {
                     });
                 });
                 expect(updated).to.deep.include({
+                    name: 'CR-001',
                     description: 'AWESOME CHANGE',
                     createdBy: { id: users.a.id },
                     updatedBy: { id: users.b.id },
@@ -212,6 +221,7 @@ describe('#ChangeRequestDao', function () {
                     );
                 });
                 expect(updated).to.deep.include({
+                    name: 'CR-001',
                     cycle: ChangeRequestCycle.Approved,
                     createdBy: { id: users.a.id },
                     updatedBy: { id: users.b.id },

--- a/packages/server-db/test/change-review.ts
+++ b/packages/server-db/test/change-review.ts
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
 import { ApprovalDecision } from '@engspace/core';
-import { trackedBy } from '../src';
+import { trackedBy, expTrackedTime } from '../src';
 import { dao, pool, th } from '.';
-import { expTrackedTime } from '../dist';
 
 describe('#ChangeReviewDao', function () {
     let users;

--- a/packages/server-db/test/change-review.ts
+++ b/packages/server-db/test/change-review.ts
@@ -5,11 +5,11 @@ import { dao, pool, th } from '.';
 
 describe('#ChangeReviewDao', function () {
     let users;
-    let req;
+    let cr;
     before(async function () {
         await pool.transaction(async (db) => {
             users = await th.createUsersAB(db);
-            req = await th.createChangeRequest(db, users.a);
+            cr = await th.createChangeRequest(db, users.a);
         });
     });
     after(th.cleanTables(['change_request', 'user']));
@@ -20,13 +20,13 @@ describe('#ChangeReviewDao', function () {
         it('should create a ChangeReview', async function () {
             const rev = await pool.transaction(async (db) => {
                 return dao.changeReview.create(db, {
-                    requestId: req.id,
+                    requestId: cr.id,
                     assigneeId: users.b.id,
                     userId: users.a.id,
                 });
             });
             expect(rev).to.deep.include({
-                request: { id: req.id },
+                request: { id: cr.id },
                 assignee: { id: users.b.id },
                 decision: ApprovalDecision.Pending,
                 comments: null,
@@ -37,14 +37,14 @@ describe('#ChangeReviewDao', function () {
         it('should create a ChangeReview with decision', async function () {
             const rev = await pool.transaction(async (db) => {
                 return dao.changeReview.create(db, {
-                    requestId: req.id,
+                    requestId: cr.id,
                     assigneeId: users.b.id,
                     userId: users.a.id,
                     decision: ApprovalDecision.Reserved,
                 });
             });
             expect(rev).to.deep.include({
-                request: { id: req.id },
+                request: { id: cr.id },
                 assignee: { id: users.b.id },
                 decision: ApprovalDecision.Reserved,
                 comments: null,
@@ -55,7 +55,7 @@ describe('#ChangeReviewDao', function () {
         it('should create a ChangeReview with decision and comments', async function () {
             const rev = await pool.transaction(async (db) => {
                 return dao.changeReview.create(db, {
-                    requestId: req.id,
+                    requestId: cr.id,
                     assigneeId: users.b.id,
                     userId: users.a.id,
                     decision: ApprovalDecision.Reserved,
@@ -63,7 +63,7 @@ describe('#ChangeReviewDao', function () {
                 });
             });
             expect(rev).to.deep.include({
-                request: { id: req.id },
+                request: { id: cr.id },
                 assignee: { id: users.b.id },
                 decision: ApprovalDecision.Reserved,
                 comments: 'Some comment',
@@ -76,24 +76,24 @@ describe('#ChangeReviewDao', function () {
         let reviews;
         before(async function () {
             return pool.transaction(async (db) => {
-                reviews = [await th.createChangeReview(db, req, users.a, users.b)];
+                reviews = [await th.createChangeReview(db, cr, users.a, users.b)];
             });
         });
 
         after(th.cleanTable('change_review'));
 
         it('should read ChangeReview by request id', async function () {
-            const cr = await pool.connect(async (db) => {
-                return dao.changeReview.byRequestId(db, req.id);
+            const req = await pool.connect(async (db) => {
+                return dao.changeReview.byRequestId(db, cr.id);
             });
-            expect(cr).to.have.same.deep.members(reviews);
+            expect(req).to.have.same.deep.members(reviews);
         });
 
         it('should return empty if no ChangeeReview', async function () {
-            const cr = await pool.connect(async (db) => {
+            const req = await pool.connect(async (db) => {
                 return dao.changeReview.byRequestId(db, '-1');
             });
-            expect(cr).to.be.empty;
+            expect(req).to.be.empty;
         });
     });
 
@@ -101,14 +101,14 @@ describe('#ChangeReviewDao', function () {
         let review;
         before(async function () {
             return pool.transaction(async (db) => {
-                review = await th.createChangeReview(db, req, users.a, users.b);
+                review = await th.createChangeReview(db, cr, users.a, users.b);
             });
         });
         after(th.cleanTable('change_review'));
 
         it('should read ChangeReview by request and assignee id', async function () {
             const rc = await pool.connect(async (db) => {
-                return dao.changeReview.byRequestAndAssigneeId(db, req.id, users.a.id);
+                return dao.changeReview.byRequestAndAssigneeId(db, cr.id, users.a.id);
             });
             expect(rc).to.deep.include({
                 id: review.id,
@@ -118,7 +118,7 @@ describe('#ChangeReviewDao', function () {
 
         it('should return null if no review for user and change request', async function () {
             const rc = await pool.connect(async (db) => {
-                return dao.changeReview.byRequestAndAssigneeId(db, req.id, users.b.id);
+                return dao.changeReview.byRequestAndAssigneeId(db, cr.id, users.b.id);
             });
             expect(rc).to.be.null;
         });
@@ -128,7 +128,7 @@ describe('#ChangeReviewDao', function () {
         let review;
         beforeEach(async function () {
             return pool.transaction(async (db) => {
-                review = await th.createChangeReview(db, req, users.a, users.b);
+                review = await th.createChangeReview(db, cr, users.a, users.b);
             });
         });
         afterEach(th.cleanTable('change_review'));

--- a/packages/server-db/test/global-counter.ts
+++ b/packages/server-db/test/global-counter.ts
@@ -1,0 +1,59 @@
+import { sql } from 'slonik';
+import { expect } from 'chai';
+import { pool, th, dao } from '.';
+
+describe('#GlobalCounterDao', function () {
+    afterEach(th.resetChangeCounter());
+    describe('#peekChangeRequest', function () {
+        it('peeks the change_request counter', async function () {
+            await pool.transaction((db) =>
+                db.query(sql`UPDATE global_counter SET change_request=1234`)
+            );
+            const counter = await pool.transaction((db) => {
+                return dao.globalCounter.peekChangeRequest(db);
+            });
+            expect(counter).to.equal(1234);
+        });
+    });
+
+    describe('#bumpChangeRequest', function () {
+        it('bumps the change_request counter in parallel (transac)', async function () {
+            const counts = await pool.transaction(async (db) => {
+                return Promise.all([
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                ]);
+            });
+            const expected = [...Array(10).keys()].map((i) => i + 1);
+            expect(counts).to.have.deep.members(expected);
+        });
+        it('bumps the change_request counter in parallel (connect)', async function () {
+            const counts = await pool.connect(async (db) => {
+                return Promise.all([
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                    dao.globalCounter.bumpChangeRequest(db),
+                ]);
+            });
+            const expected = [...Array(10).keys()].map((i) => i + 1);
+            expect(counts).to.have.deep.members(expected);
+        });
+    });
+});

--- a/packages/server-db/test/part-approval.ts
+++ b/packages/server-db/test/part-approval.ts
@@ -6,7 +6,7 @@ import { dao, pool, th } from '.';
 describe('#PartApprovalDao', function () {
     let users;
     let fam;
-    let req;
+    let cr;
     let part;
     let partRev;
     let partVal;
@@ -20,9 +20,9 @@ describe('#PartApprovalDao', function () {
                 e: { name: 'e' },
             });
             fam = await th.createPartFamily(db);
-            req = await th.createChangeRequest(db, users.a);
+            cr = await th.createChangeRequest(db, users.a);
             part = await th.createPart(db, fam, users.a, {});
-            partRev = await th.createPartRev(db, part, req, users.a);
+            partRev = await th.createPartRev(db, part, cr, users.a);
             partVal = await th.createPartVal(db, partRev, users.a);
         });
     });

--- a/packages/server-db/test/part-revision.ts
+++ b/packages/server-db/test/part-revision.ts
@@ -19,7 +19,7 @@ describe('#PartRevisionDao', function () {
     this.beforeEach(function () {
         return pool.transaction(async (db) => {
             part = await th.createPart(db, family, users.a, { ref: 'P001.A' });
-            req = await th.createChangeRequest(db, users.a);
+            req = await th.createChangeRequest(db, users.a, 'CR-001');
         });
     });
 
@@ -90,9 +90,9 @@ describe('#PartRevisionDao', function () {
 
         this.beforeEach(function () {
             return pool.transaction(async (db) => {
-                reqA = await th.createChangeRequest(db, users.a);
-                reqB = await th.createChangeRequest(db, users.a);
-                reqC = await th.createChangeRequest(db, users.a);
+                reqA = req;
+                reqB = await th.createChangeRequest(db, users.a, 'CR-002');
+                reqC = await th.createChangeRequest(db, users.a, 'CR-003');
                 part1a = part;
                 part1b = await th.createPart(db, family, users.a, {
                     ref: 'P001.B',

--- a/packages/server-db/test/part-revision.ts
+++ b/packages/server-db/test/part-revision.ts
@@ -126,7 +126,7 @@ describe('#PartRevisionDao', function () {
 
         it('should get all revisions above 1 for a change request', async function () {
             const { revsA, revsB, revsC } = await pool.connect(async (db) => {
-                const revsA = await dao.partRevision.aboveRev1ByChangeRequestId(db, cr2.id);
+                const revsA = await dao.partRevision.aboveRev1ByChangeRequestId(db, cr1.id);
                 const revsB = await dao.partRevision.aboveRev1ByChangeRequestId(db, cr2.id);
                 const revsC = await dao.partRevision.aboveRev1ByChangeRequestId(db, cr3.id);
                 return { revsA, revsB, revsC };

--- a/packages/server-db/test/part-validation.ts
+++ b/packages/server-db/test/part-validation.ts
@@ -6,7 +6,7 @@ import { dao, pool, th } from '.';
 describe('#PartValidationDao', function () {
     let users;
     let fam;
-    let req;
+    let cr;
     let part;
     let partRev;
     before('create deps', async function () {
@@ -19,9 +19,9 @@ describe('#PartValidationDao', function () {
                 e: { name: 'e' },
             });
             fam = await th.createPartFamily(db, { code: 'P' });
-            req = await th.createChangeRequest(db, users.a);
+            cr = await th.createChangeRequest(db, users.a);
             part = await th.createPart(db, fam, users.a, {});
-            partRev = await th.createPartRev(db, part, req, users.a);
+            partRev = await th.createPartRev(db, part, cr, users.a);
         });
     });
     after(

--- a/packages/server-db/test/part.ts
+++ b/packages/server-db/test/part.ts
@@ -98,8 +98,8 @@ describe('#PartDao', function () {
 
         this.beforeEach(function () {
             return pool.transaction(async (db) => {
-                reqA = await th.createChangeRequest(db, users.a);
-                reqB = await th.createChangeRequest(db, users.a);
+                reqA = await th.createChangeRequest(db, users.a, 'CR-001');
+                reqB = await th.createChangeRequest(db, users.a, 'CR-002');
                 part1a = await th.createPart(
                     db,
                     family,
@@ -107,7 +107,7 @@ describe('#PartDao', function () {
                     {
                         ref: 'P001.A',
                     },
-                    { withRev1: true, changeRequest: reqA, bumpFamCounter: false }
+                    { withRev1: { changeRequest: reqA }, bumpFamCounter: false }
                 );
                 part1b = await th.createPart(
                     db,
@@ -116,7 +116,7 @@ describe('#PartDao', function () {
                     {
                         ref: 'P001.B',
                     },
-                    { withRev1: true, changeRequest: reqB, bumpFamCounter: false }
+                    { withRev1: { changeRequest: reqB }, bumpFamCounter: false }
                 );
                 part2a = await th.createPart(
                     db,
@@ -125,7 +125,7 @@ describe('#PartDao', function () {
                     {
                         ref: 'P002.A',
                     },
-                    { withRev1: true, changeRequest: reqA, bumpFamCounter: false }
+                    { withRev1: { changeRequest: reqA }, bumpFamCounter: false }
                 );
                 part2b = await th.createPart(
                     db,
@@ -134,7 +134,7 @@ describe('#PartDao', function () {
                     {
                         ref: 'P002.B',
                     },
-                    { withRev1: true, changeRequest: reqB, bumpFamCounter: false }
+                    { withRev1: { changeRequest: reqB }, bumpFamCounter: false }
                 );
             });
         });

--- a/packages/server-db/test/part.ts
+++ b/packages/server-db/test/part.ts
@@ -92,14 +92,14 @@ describe('#PartDao', function () {
     });
 
     describe('#whoseRev1IsCreatedBy', function () {
-        let reqA: ChangeRequest, reqB: ChangeRequest;
+        let cr1: ChangeRequest, cr2: ChangeRequest;
         let part1a: Part, part1b: Part;
         let part2a: Part, part2b: Part;
 
         this.beforeEach(function () {
             return pool.transaction(async (db) => {
-                reqA = await th.createChangeRequest(db, users.a, 'CR-001');
-                reqB = await th.createChangeRequest(db, users.a, 'CR-002');
+                cr1 = await th.createChangeRequest(db, users.a, 'CR-001');
+                cr2 = await th.createChangeRequest(db, users.a, 'CR-002');
                 part1a = await th.createPart(
                     db,
                     family,
@@ -107,7 +107,7 @@ describe('#PartDao', function () {
                     {
                         ref: 'P001.A',
                     },
-                    { withRev1: { changeRequest: reqA }, bumpFamCounter: false }
+                    { withRev1: { changeRequest: cr1 }, bumpFamCounter: false }
                 );
                 part1b = await th.createPart(
                     db,
@@ -116,7 +116,7 @@ describe('#PartDao', function () {
                     {
                         ref: 'P001.B',
                     },
-                    { withRev1: { changeRequest: reqB }, bumpFamCounter: false }
+                    { withRev1: { changeRequest: cr2 }, bumpFamCounter: false }
                 );
                 part2a = await th.createPart(
                     db,
@@ -125,7 +125,7 @@ describe('#PartDao', function () {
                     {
                         ref: 'P002.A',
                     },
-                    { withRev1: { changeRequest: reqA }, bumpFamCounter: false }
+                    { withRev1: { changeRequest: cr1 }, bumpFamCounter: false }
                 );
                 part2b = await th.createPart(
                     db,
@@ -134,7 +134,7 @@ describe('#PartDao', function () {
                     {
                         ref: 'P002.B',
                     },
-                    { withRev1: { changeRequest: reqB }, bumpFamCounter: false }
+                    { withRev1: { changeRequest: cr2 }, bumpFamCounter: false }
                 );
             });
         });
@@ -142,10 +142,10 @@ describe('#PartDao', function () {
 
         it('should get all parts whose rev1 created by request', async function () {
             const partsA = await pool.connect(async (db) => {
-                return dao.part.whoseRev1IsCreatedBy(db, reqA.id);
+                return dao.part.whoseRev1IsCreatedBy(db, cr1.id);
             });
             const partsB = await pool.connect(async (db) => {
-                return dao.part.whoseRev1IsCreatedBy(db, reqB.id);
+                return dao.part.whoseRev1IsCreatedBy(db, cr2.id);
             });
             expect(partsA).to.containSubset([
                 {

--- a/packages/server-db/test/pool_schema.ts
+++ b/packages/server-db/test/pool_schema.ts
@@ -73,6 +73,7 @@ describe('Pool and Schema', async () => {
                 'change_request_cycle_enum',
 
                 'metadata',
+                'global_counter',
                 'user',
                 'user_login',
                 'user_role',


### PR DESCRIPTION
Name is unique, fix width and contains a counter.

 - Naming is made more generic
 - ChangeRequestNaming is created to allow an application dependent naming configuration
 - The current counter is tracked by a table 'global_counter', that can also contain other global counters (such as document, files, to be implemented later)
 - Name field added on ChangeRequest graphql and in change_request table
 - Tests updated